### PR TITLE
Lock port 80 by default

### DIFF
--- a/cheminformatics/cdk.json
+++ b/cheminformatics/cdk.json
@@ -22,6 +22,7 @@
     "ec2_volume_size": 100,
     "instance_type": "p3.2xlarge",
     "megamolbart_container": "nvcr.io/nvidia/clara/megamolbart_v0.2:0.2.0",
+    "security_group_ip_range": null,
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,


### PR DESCRIPTION
*Description of changes:*

Adds a new parameter to cdk.json for CIDR ranges that can access the load balancer on port 80.

Here is the behavior:

By default the parameter is set to null and no listener will be added to the security group. Which means there is no external access at all.

If you add a CIDR block, that IP range will be allow listed by the security group on port 80.
